### PR TITLE
Compiler filtes translation

### DIFF
--- a/camelus.opam
+++ b/camelus.opam
@@ -10,7 +10,7 @@ depends: [
   "cohttp-lwt-unix"
   "opam-format" {>= "2.0.0~beta5"}
   "opam-solver" {>= "2.0.0~beta5"}
-  "opam-state" {>= "2.0.0~beta5"}
+  "opam-state" {>= "2.0.0"}
   "git-unix" {>= "1.11" & < "2.0"}
   "fpath"
   "github-unix"
@@ -22,4 +22,5 @@ build: ["jbuilder" "build" "-p" name]
 pin-depends: [
   ["github.3.0.1" "git+https://github.com/AltGr/ocaml-github#21efde3"]
   ["github-unix.3.0.1" "git+https://github.com/AltGr/ocaml-github#21efde3"]
+  ["opam-state.2.0.0" "git+https://github.com/ocaml/opam#2d318cb8"]
 ]

--- a/camelus_lib.ml
+++ b/camelus_lib.ml
@@ -321,7 +321,7 @@ module FormatUpgrade = struct
             (OpamPackage.Version.of_string (version^"+"^variant))
       in
       let opam =
-        OpamFile.Comp.to_package ~package:nv comp descr |>
+        OpamFormatUpgrade.comp_file ~package:nv ?descr comp |>
         OpamFile.OPAM.with_conflict_class
           [OpamPackage.Name.of_string "ocaml-core-compiler"]
       in


### PR DESCRIPTION
This PR is related to https://github.com/ocaml/opam-repository/pull/12523#issuecomment-418679440: compiler package translation was not complete, filters and vars are kept as is.
PR https://github.com/ocaml/opam/pull/3530 added function  `OpamFormatUpgrade.comp_file` which correct this, and is used in commit https://github.com/AltGr/Camelus/commit/28f3a36c7f5670a73dbb1c8616443d20c6d1a03a.
So that means that `opam-state` is pinned to the commit introducing this function (commit https://github.com/AltGr/Camelus/commit/6508ea272a92eef8f0e3d45036537556df1a1138).