### PR TITLE
Add compatibility with lwt >= 4.0.0

### DIFF
--- a/jbuild
+++ b/jbuild
@@ -6,7 +6,7 @@
   (wrapped false)
   (modules camelus_lib)
   (libraries (lwt.unix conduit-lwt cohttp-lwt opam-format opam-solver opam-state cohttp-lwt-unix fpath yojson nocrypto github-unix))
-  (preprocess (pps (lwt.ppx)))
+  (preprocess (pps (lwt_ppx)))
 ))
 
 (executable(
@@ -14,7 +14,7 @@
   (public_name camelus)
   (modules camelus_main)
   (libraries (camelus))
-  (preprocess (pps (lwt.ppx)))
+  (preprocess (pps (lwt_ppx)))
 ))
 
 (executable(
@@ -23,5 +23,5 @@
   (package camelus)
   (modules camelus_replay)
   (libraries (camelus))
-  (preprocess (pps (lwt.ppx)))
+  (preprocess (pps (lwt_ppx)))
 ))


### PR DESCRIPTION
The `lwt.ppx` package has been removed since lwt 3.2.0 and has been replaced with an external package `lwt_ppx`