### PR TITLE
Addfork

### DIFF
--- a/camelus.opam
+++ b/camelus.opam
@@ -23,7 +23,3 @@ depends: [
   "fpath"
 ]
 build: ["dune" "build" "-p" name]
-pin-depends: [
-  ["github.3.1.0" "git+https://github.com/AltGr/ocaml-github#21efde3"]
-  ["github-unix.3.1.0" "git+https://github.com/AltGr/ocaml-github#21efde3"]
-]

--- a/camelus_child.ml
+++ b/camelus_child.ml
@@ -1,0 +1,32 @@
+open Camelus_lib
+
+let conf = Conf.read (OpamFile.make (OpamFilename.of_string "opam-ci.conf"))
+
+let name = conf.Conf.name
+let token = conf.Conf.token
+
+let repo = {
+  user = "ocaml";
+  name = "opam-repository";
+  auth = Some (name, Github.Token.to_string token);
+}
+
+let base_branch = "master"
+let dest_branch = "2.0.0"
+
+let _ =
+  let pr = Fork_handler.delinearize_pr Sys.argv 1 in
+  Lwt_main.run begin
+    let%lwt gitstore = match%lwt RepoGit.get repo with
+      | Ok r -> Lwt.return r
+      | Error e -> Lwt.fail (Failure "Repository loading failed")
+    in
+    let%lwt status,body = PrChecks.run_nogit ~conf pr gitstore in
+    Github.(
+      Monad.(run @@ begin
+          let state,text = Github_comment.make_status status in
+          GH.comment conf pr body >>= fun _ ->
+          GH.status conf pr state (Some text)
+        end)
+    )
+  end

--- a/camelus_child.ml
+++ b/camelus_child.ml
@@ -1,5 +1,7 @@
 open Camelus_lib
 
+let () = log "here"
+
 let conf = Conf.read (OpamFile.make (OpamFilename.of_string "opam-ci.conf"))
 
 let name = conf.Conf.name

--- a/camelus_child.ml
+++ b/camelus_child.ml
@@ -16,12 +16,17 @@ let dest_branch = "2.0.0"
 
 let _ =
   let pr = Fork_handler.delinearize_pr Sys.argv 1 in
+  let msghead = Sys.argv.(pred @@ Array.length Sys.argv) in
+  Lwt.with_value log_tag (Some (string_of_int pr.number)) @@
+  fun () ->
+  log "Pr handled in child process";
   Lwt_main.run begin
     let%lwt gitstore = match%lwt RepoGit.get repo with
       | Ok r -> Lwt.return r
       | Error e -> Lwt.fail (Failure "Repository loading failed")
     in
-    let%lwt status,body = PrChecks.run_nogit ~conf pr gitstore in
+    log "repo gotten, running checks";
+    let%lwt status,body = PrChecks.run_nogit ~conf pr gitstore msghead in
     Github.(
       Monad.(run @@ begin
           let state,text = Github_comment.make_status status in

--- a/camelus_lib.ml
+++ b/camelus_lib.ml
@@ -18,7 +18,15 @@
 
 open Lwt.Infix
 
-let log fmt = OpamConsole.msg (fmt ^^ "\n%!")
+let log_tag : string Lwt.key= Lwt.new_key ()
+
+let log fmt =
+  let tag =
+    match Lwt.get log_tag with
+    | None -> "??"
+    | Some s -> s
+  in
+  OpamConsole.msg ("[%s] "^^ fmt ^^ "\n%!") tag
 
 let verbose =
   try Sys.getenv "CAMELUS_VERBOSE" <> ""

--- a/camelus_main.ml
+++ b/camelus_main.ml
@@ -35,7 +35,7 @@ let handler conf gitstore = function
        pr.head.repo.user pr.head.repo.name pr.head.ref
        pr.head.sha pr.base.sha;
      try%lwt
-       let%lwt report = PrChecks.run pr gitstore in
+       let%lwt report = PrChecks.run ~conf pr gitstore in
        Github_comment.push_report
          ~name:conf.Conf.name
          ~token:conf.Conf.token

--- a/camelus_main.ml
+++ b/camelus_main.ml
@@ -36,12 +36,14 @@ let handler conf gitstore = function
           pr.head.repo.user pr.head.repo.name pr.head.ref
           pr.head.sha pr.base.sha;
         try%lwt
-          let%lwt report = PrChecks.run ~conf pr gitstore in
-          Github_comment.push_report
-            ~name:conf.Conf.name
-            ~token:conf.Conf.token
-            ~report
-            pr
+          (* let%lwt report = PrChecks.run ~conf pr gitstore in
+           * Github_comment.push_report
+           *   ~name:conf.Conf.name
+           *   ~token:conf.Conf.token
+           *   ~report
+           *   pr *)
+          RepoGit.fetch_pr pr gitstore >>= fun () ->
+          Fork_handler.process ~conf pr
         with exn ->
           log "Check failed: %s" (Printexc.to_string exn);
           let%lwt _ =

--- a/camelus_main.ml
+++ b/camelus_main.ml
@@ -50,35 +50,35 @@ let handler conf gitstore = function
               ~text:"Could not complete" `Failure
           in
           Lwt.return_unit)
-  | `Push p when List.mem `Push_upgrader conf.Conf.roles ->
-    (log "=> Push received (head %s onto %s)"
-       p.push_head p.push_ancestor;
-     let auth = conf.Conf.name, Github.Token.to_string conf.Conf.token in
-     let%lwt pr_branch =
-       try%lwt
-         FormatUpgrade.run conf.Conf.base_branch conf.Conf.dest_branch
-           p.push_ancestor p.push_head gitstore
-           { p.push_repo with auth = Some auth }
-       with exn ->
-         log "Upgrade commit failed: %s" (Printexc.to_string exn);
-         Lwt.return None
-     in
-     match pr_branch with
-     | None -> Lwt.return_unit
-     | Some (branch, msg) ->
-       let title, message =
-         match OpamStd.String.cut_at msg '\n' with
-         | Some (t, m) -> t, Some (String.trim m)
-         | None -> "Merge changes from 1.2 format repo", None
-       in
-       try%lwt
-         Github_comment.pull_request
-           ~name:conf.Conf.name ~token:conf.Conf.token conf.Conf.repo
-           branch conf.Conf.dest_branch
-           ?message title
-       with exn ->
-         log "Pull request failed: %s" (Printexc.to_string exn);
-         Lwt.return_unit)
+  (* | `Push p when List.mem `Push_upgrader conf.Conf.roles ->
+   *   (log "=> Push received (head %s onto %s)"
+   *      p.push_head p.push_ancestor;
+   *    let auth = conf.Conf.name, Github.Token.to_string conf.Conf.token in
+   *    let%lwt pr_branch =
+   *      try%lwt
+   *        FormatUpgrade.run conf.Conf.base_branch conf.Conf.dest_branch
+   *          p.push_ancestor p.push_head gitstore
+   *          { p.push_repo with auth = Some auth }
+   *      with exn ->
+   *        log "Upgrade commit failed: %s" (Printexc.to_string exn);
+   *        Lwt.return None
+   *    in
+   *    match pr_branch with
+   *    | None -> Lwt.return_unit
+   *    | Some (branch, msg) ->
+   *      let title, message =
+   *        match OpamStd.String.cut_at msg '\n' with
+   *        | Some (t, m) -> t, Some (String.trim m)
+   *        | None -> "Merge changes from 1.2 format repo", None
+   *      in
+   *      try%lwt
+   *        Github_comment.pull_request
+   *          ~name:conf.Conf.name ~token:conf.Conf.token conf.Conf.repo
+   *          branch conf.Conf.dest_branch
+   *          ?message title
+   *      with exn ->
+   *        log "Pull request failed: %s" (Printexc.to_string exn);
+   *        Lwt.return_unit) *)
   | _ -> Lwt.return_unit
 
 let () =
@@ -91,6 +91,7 @@ let () =
         (OpamFile.to_string f) (Printexc.to_string e);
       exit 3
   in
+  let gh_loop = GH.loop ~conf () in
   let event_stream, event_push = Lwt_stream.create () in
   let rec check_loop gitstore =
     match%lwt Lwt_stream.next event_stream with
@@ -118,11 +119,12 @@ let () =
     in
     Lwt.return (event_push (Some event))
   in
-  Lwt_main.run (Lwt.join [
+  Lwt_main.run (Lwt.choose [
       (match%lwt RepoGit.get conf.Conf.repo with
        | Ok r -> check_loop r
        | Error e -> Lwt.fail (Failure "Repository loading failed"));
       Webhook_handler.server
         ~conf
         ~handler;
+      gh_loop;
     ])

--- a/camelus_replay.ml
+++ b/camelus_replay.ml
@@ -134,7 +134,8 @@ let () =
         | Ok r -> Lwt.return r
         | Error e -> Lwt.fail (Failure "Repository loading failed")
       in
-      Lwt_list.iter_p (replay_pr_fork gitstore) l
+      Lwt_list.iter_p (replay_pr_fork gitstore) l >>= fun () ->
+      Lwt.join @@ Fork_handler.pending_processes ()
     end
   | _ ->
     OpamConsole.msg "Usage: %s auto or %s check PR# or %s check-bunch PR#...\n" Sys.argv.(0) Sys.argv.(0) Sys.argv.(0);

--- a/camelus_replay.ml
+++ b/camelus_replay.ml
@@ -15,10 +15,10 @@ let base_branch = "master"
 let dest_branch = "2.0.0"
 
 let get_pr num =
-  Github.Monad.run @@
-  let open Github.Monad in
-    Github.Pull.get ~user:repo.user ~repo:repo.name ~num () >|=
-    Github.Response.value
+  GH.run (fun () ->
+      let open Github.Monad in
+      Github.Pull.get ~user:repo.user ~repo:repo.name ~num () >|=
+      Github.Response.value)
 
 open Lwt.Infix
 open Github_t

--- a/dune
+++ b/dune
@@ -33,3 +33,12 @@
  (libraries camelus)
  (preprocess (pps lwt_ppx))
 )
+
+(executable
+ (name camelus_child)
+ (public_name camelus_child)
+ (package camelus)
+ (modules camelus_child)
+ (libraries camelus)
+ (preprocess (pps lwt_ppx))
+)

--- a/test_linearize.ml
+++ b/test_linearize.ml
@@ -1,0 +1,19 @@
+open Camelus_lib
+
+let pr = {
+  number = 42;
+  base = { repo = { user = "pat"; name = "johnson"; auth = None; };
+           ref = "PatJ";
+           sha = "cha cha"; };
+  head = { repo = { user = "tom"; name = "thomas"; auth = Some ("T","B"); };
+           ref = "Tom";
+           sha = "chi chi"; };
+  pr_user = "blanc";
+  message = "prout","caca";
+}
+
+let a = Fork_handler.linearize_pr pr
+let a' = Array.append (Array.make 42 "") a
+let () = Array.iter print_endline a
+
+let () = assert Fork_handler.(delinearize_pr a' 42 = pr)


### PR DESCRIPTION
Camelus will now have children!

This will execute the checks into subprocesses, killing them if a new update is coming to the PR.

Has been tested on `camelus_replay` (argument autofork) but not deployed yet.

ping @kit-ty-kate 